### PR TITLE
Added note about username in crontab entry

### DIFF
--- a/book/jobs.rst
+++ b/book/jobs.rst
@@ -25,11 +25,18 @@ Configuring the Entry Point Command
 
 All you have to do to regularly run a set of commands from your application
 is to configure your system to run the ``oro:cron`` command every minute.
-On UNIX-based systems, you can simply use the Crontab for this:
+On UNIX-based systems, you can simply set up a ``crontab`` entry for this:
 
 .. code-block:: text
 
     */1 * * * * /path/to/php /path/to/app/console oro:cron --env=prod > /dev/null
+    
+Note: Some OS flavors will require the user name(usually root) in the crontab entry,
+like this:
+	
+.. code-block:: text
+
+    */1 * * * * root /path/to/php /path/to/app/console oro:cron --env=prod > /dev/null
 
 On Windows, use the Control Panel to configure the Task Scheduler to do the
 same.


### PR DESCRIPTION
I found out today that CentOS 7 (and most likely other 'nix flavors) requires crontab entries to have a username in them.  My Job Queue daemon was dying every few hours and I found out that it was because the crontab wasn't executing due to not having the root username in the entry.  After we added that, it was all good.  Thought I'd add a note to the docs to try and save somebody some time!