### PR TITLE
more configuration format references (assets, search, and system configuration)

### DIFF
--- a/book/layout.rst
+++ b/book/layout.rst
@@ -61,6 +61,8 @@ apply multiple filters.
     Refer to the `Assetic documentation`_ for a list of available filters and read the `cookbook`_
     in the Symfony documentation to learn more about Assetic.
 
+.. _book-layout-debugging-css:
+
 Debugging Your Stylesheets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/reference/format/assets.rst
+++ b/reference/format/assets.rst
@@ -1,2 +1,50 @@
 Assets
 ======
+
++-----------+----------------+
+| Filename  | ``assets.yml`` |
++-----------+----------------+
+| Root Node | ``css``        |
++-----------+----------------+
+
+The ``assets.yml`` file can be used to define CSS file groups. The listed files will be
+automatically merged and optimized for web presentation.
+
+The following example creates two groups (``first_group`` and ``second_group``) each of them
+containing three CSS files:
+
+.. code-block:: yaml
+    :linenos:
+
+    # src/Acme/DemoBundle/Resources/config/assets.yml
+    css:
+        first_group:
+            - 'First/Assets/Path/To/Css/first.css'
+            - 'First/Assets/Path/To/Css/second.css'
+            - 'First/Assets/Path/To/Css/third.css'
+        second_group:
+            - 'Second/Assets/Path/To/Css/first.css'
+            - 'Second/Assets/Path/To/Css/second.css'
+            - 'Second/Assets/Path/To/Css/third.css'
+
+By default, when you install the application's assets using the ``oro:assets:install`` command, all
+CSS files from all groups and all bundles will be merged and optimized.
+
+For debugging purposes compression of CSS files of certain groups can be disabled with the
+``css_debug`` option:
+
+.. code-block:: yaml
+    :linenos:
+
+    oro_assetic:
+        css_debug:
+            - first_group
+
+.. tip::
+
+    You can use the ``oro:assetic:groups`` command to get a list of all available groups.
+
+.. seealso::
+
+    Learn more about :ref:`how to debug your stylesheets <book-layout-debugging-css>` from the
+    book.

--- a/reference/format/importexport.rst
+++ b/reference/format/importexport.rst
@@ -1,2 +1,0 @@
-Import and Export
-=================

--- a/reference/format/index.rst
+++ b/reference/format/index.rst
@@ -9,9 +9,9 @@ Configuration Format Reference
     dashboard
     datagrid
     entity_config
-    importexport
     navigation
     placeholders
     requirejs
     search
+    system_configuration
     workflow

--- a/reference/format/search.rst
+++ b/reference/format/search.rst
@@ -1,2 +1,212 @@
 Search Index
 ============
+
++-----------+------------------------------------------------------------+
+| Filename  | ``search.yml``                                             |
++-----------+------------------------------------------------------------+
+| Root Node | The fully qualified class name of the entity being indexed |
++-----------+------------------------------------------------------------+
+| Options   | * `alias`_                                                 |
+|           | * `fields`_                                                |
+|           |                                                            |
+|           |   * :ref:`name <reference-format-search-fields-name>`      |
+|           |   * `relation_fields`_                                     |
+|           |   * `relation_type`_                                       |
+|           |   * `target_fields`_                                       |
+|           |   * `target_type`_                                         |
+|           |                                                            |
+|           | * `label`_                                                 |
+|           | * `mode`_                                                  |
+|           | * `route`_                                                 |
+|           |                                                            |
+|           |   * :ref:`name <reference-format-search-route-name>`       |
+|           |   * `parameters`_                                          |
+|           |                                                            |
+|           | * `search_template`_                                       |
+|           | * `title_fields`_                                          |
++-----------+------------------------------------------------------------+
+
+The ``search.yml`` file is used to configure how your entities are indexed to make them usable by
+the internal search engine of the OroPlatform. A fully working example can look like this:
+
+.. code-block:: yaml
+    :linenos:
+
+    # src/Acme/DemoBundle/Resources/config/search.yml
+    Acme\DemoBundle\Entity\Product:
+        alias: demo_product
+        search_template: AcmeDemoBundle:result.html.twig
+        label: Demo products
+        route:
+            name: acme_demo_search_product
+            parameters:
+                id: id
+        mode: normal
+        title_fields: [name]
+        fields:
+            -
+                name: name
+                target_type: text
+            -
+                name: description
+                target_type: text
+                target_fields: [description, another_index_name]  parameter.
+            -
+                name: manufacturer
+                relation_type: many-to-one
+                relation_fields:
+                    -
+                        name: name
+                        target_type: text
+                        target_fields: [manufacturer, all_data]
+                    -
+                        name: id
+                        target_type: integer
+                        target_fields: [manufacturer]
+            -
+                name: categories
+                relation_type: many-to-many
+                relation_fields:
+                    -
+                        name: name
+                        target_type: text
+                        target_fields: [all_data]
+
+``alias``
+---------
+
+**type**: ``string``
+
+An alias used in the ``from`` keyword in :ref:`advanced search <advanced-search-api>`.
+
+.. _reference-format-search-fields:
+
+``fields``
+----------
+
+**type**: ``sequence``
+
+The list of fields that will be added to the search index. Each entry must be a map that can use
+the following keys to configure how the property value will be indexed:
+
+.. _reference-format-search-fields-name:
+
+``name``
+~~~~~~~~
+
+**type**: ``string``
+
+The name of the entity property. This option is required.
+
+``relation_fields``
+~~~~~~~~~~~~~~~~~~~
+
+**type**: ``sequence``
+
+When the field represents an association (i.e. a value is configured for `relation_type`_), this is
+a list of fields from the target entity to index. For each entry all the options of the parent
+:ref:`fields option <reference-format-search-fields>` apply.
+
+``relation_type``
+~~~~~~~~~~~~~~~~~
+
+**type**: ``string``
+
+When the property denotes an association with another entity, the type of association (one of
+``one-to-one``, ``many-to-many``, ``one-to-many``, or ``many-to-one``) must be configured with this
+option.
+
+``target_fields``
+~~~~~~~~~~~~~~~~~
+
+**type**: ``sequence``
+
+The ``target_fields`` option list the named indexes to which the property value will be added.
+
+For example, a contact may have the properties ``firstName``, ``lastName``, and ``namePrefix`` and
+all three properties should be searched when the user is loooking for a value in the virtual
+``name`` field (when using the advanced search API). In this case, all three properties will list
+the ``name`` field in ``target_fields``:
+
+.. code-block:: yaml
+    :linenos:
+
+    Acme\ContactBunde\Entity\Contact:
+        fields:
+            - name: firstName
+              target_type: text
+              target_fields: [name]
+            - name: lastName
+              target_type: text
+              target_fields: [name]
+            - name: namePrefix
+              target_type: text
+              target_fields: [name]
+
+If the ``target_type`` is ``text``, the data will also be stored in the ``all_data`` field
+implicitly.
+
+If the ``target_fields`` option is not given, the data is added to a virtual field whose name is
+the name as the field's name (i.e. what is specified under the ``name`` key).
+
+``target_type``
+~~~~~~~~~~~~~~~
+
+**type**: ``string``
+
+The type of the virtual search field (possible values are ``datetime``, ``double``, ``integer``,
+and ``text``). This option is required.
+
+``label``
+---------
+
+**type**: ``string``
+
+A human readable label to identify the entity in the search results. The configured string will be
+passed to the translator.
+
+``mode``
+--------
+
+**type**: ``string`` **default**: normal
+
+The entity behavior for inheritance. For possible values and what they mean, have a look at the
+constants of the :class:`Oro\\Bundle\\SearchBundle\\Query\\Mode` class.
+
+.. _reference-format-search-route-name:
+
+``route``
+---------
+
+**type**: ``map``
+
+The route for which a URL is generated when linking from the search result to a concrete entity.
+The available options are:
+
+``name``
+~~~~~~~~
+
+**type**: ``string``
+
+The name of the route.
+
+``parameters``
+~~~~~~~~~~~~~~
+
+**type**: ``map``
+
+The routing parameters, each key is the name of the routing parameter and the value is the name of
+one of the configured :ref:`fields <reference-format-search-fields>`.
+
+``search_template``
+-------------------
+
+**type**: ``string``
+
+``title_fields``
+----------------
+
+**type**: ``sequence``
+
+The list of fields to build the title for the result set. The value used here denote to the
+:ref:`configured fields <reference-format-search-fields>`.

--- a/reference/format/system_configuration.rst
+++ b/reference/format/system_configuration.rst
@@ -1,0 +1,232 @@
+System Configuration
+====================
+
++-----------+------------------------------+
+| Filename  | ``system_configuration.yml`` |
++-----------+------------------------------+
+| Root Node | ``oro_system_configuration`` |
++-----------+------------------------------+
+| Options   | * `api_tree`_                |
+|           | * `fields`_                  |
+|           |                              |
+|           |   * `data_type`_             |
+|           |   * `options`_               |
+|           |   * `type`_                  |
+|           |                              |
+|           | * `groups`_                  |
+|           |                              |
+|           |   * `icon`_                  |
+|           |   * `title`_                 |
+|           |                              |
+|           | * `tree`_                    |
+|           |                              |
+|           |   * `children`_              |
+|           |   * `priority`_              |
++-----------+------------------------------+
+
+The ``system_configuration.yml`` file defines all the configuration options a bundle exposes which
+can be modified by the user in the system settings menu.
+
+The following example shows a complete working configuration taken from the
+`system_configuration.yml file`_ of the `ActivityListBundle`_ from the OroPlatform:
+
+.. code-block:: yaml
+    :linenos:
+
+    # src/Oro/Bundle/ActivityListBundle/Resources/config/system_configuration.yml
+    oro_system_configuration:
+        groups:
+            activity_list_settings:
+                title:  oro.activitylist.system_configuration.activity_list.label
+
+        fields:
+            oro_activity_list.sorting_field:
+                data_type: string
+                type: choice
+                options:
+                    label: oro.activitylist.system_configuration.fields.sorting_field.label
+                    choices:
+                        createdAt: oro.activitylist.system_configuration.fields.sorting_field.choices.createdAt
+                        updatedAt: oro.activitylist.system_configuration.fields.sorting_field.choices.updatedAt
+                    constraints:
+                        - NotBlank: ~
+            oro_activity_list.sorting_direction:
+                data_type: string
+                type: choice
+                options:
+                    label: oro.activitylist.system_configuration.fields.sorting_direction.label
+                    choices:
+                        DESC: oro.activitylist.system_configuration.fields.sorting_direction.choices.DESC
+                        ASC: oro.activitylist.system_configuration.fields.sorting_direction.choices.ASC
+                    constraints:
+                        - NotBlank: ~
+            oro_activity_list.per_page:
+                data_type: integer
+                type: choice
+                options:
+                    label: oro.activitylist.system_configuration.fields.per_page.label
+                    choices:
+                        10:     10
+                        25:     25
+                        50:     50
+                        100:    100
+                    constraints:
+                        - NotBlank: ~
+            oro_activity_list.grouping:
+                data_type: boolean
+                type: choice
+                options:
+                    label: oro.activitylist.system_configuration.email_threads.use_threads_in_activities.label
+                    choices:
+                        - oro.activitylist.system_configuration.email_threads.use_threads_in_activities.choices.non_threaded.label
+                        - oro.activitylist.system_configuration.email_threads.use_threads_in_activities.choices.threaded.label
+
+        tree:
+            system_configuration:
+                platform:
+                    children:
+                        general_setup:
+                            children:
+                                look_and_feel:
+                                    children:
+                                        activity_list_settings:
+                                            children:
+                                                - oro_activity_list.sorting_field
+                                                - oro_activity_list.sorting_direction
+                                                - oro_activity_list.per_page
+                                email_configuration:
+                                    children:
+                                        email_threads:
+                                            children:
+                                                - oro_activity_list.grouping
+
+        api_tree:
+            activity_list:
+                oro_activity_list.sorting_field: ~
+                oro_activity_list.sorting_direction: ~
+                oro_activity_list.per_page: ~
+            email_threads:
+                oro_activity_list.grouping: ~
+
+``api_tree``
+------------
+
+**type**: ``map``
+
+The ``api_tree`` block is used to define which configuration options will be configurable through
+the API. Nested maps can be used to create logical groups of options:
+
+.. code-block:: yaml
+    :linenos:
+
+    oro_system_configuration:
+        api_tree:
+            activity_list:
+                oro_activity_list.sorting_field: ~
+                oro_activity_list.sorting_direction: ~
+                oro_activity_list.per_page: ~
+            email_threads:
+                oro_activity_list.grouping: ~
+
+.. _reference-format-system-configuration-fields:
+
+``fields``
+----------
+
+**type**: ``map``
+
+This option specifies the list of Configuration keys the bundle provides. Each key is the name of
+a Configuration option. For each key you have to pass a map that describes how the option can be
+configured by the user. The available options for each key are:
+
+``data_type``
+~~~~~~~~~~~~~
+
+**type**: ``string``
+
+The type of data that can be stored as the option value. Supported data types are ``array``,
+``boolean``, or ``string``.
+
+``options``
+~~~~~~~~~~~
+
+**type**: ``map``
+
+The :ref:`form type <reference-format-system-configuration-type>` options. The otpions being
+available depend on the actual form type.
+
+.. _reference-format-system-configuration-type:
+
+``type``
+~~~~~~~~
+
+**type**: ``string``
+
+The name of the form type that will be rendered in the user interface to change the option value.
+
+.. _reference-format-system-configuration-groups:
+
+``groups``
+----------
+
+**type**: ``map``
+
+You can use this option to create configuration groups. The ``system_configuration.yml`` files of
+all bundles can refer to any group defined by any bundle to structure trees of config options. The
+following options exist to define a group:
+
+``icon``
+~~~~~~~~
+
+**type**: ``string``
+
+The name of a `Font Awesome Icon`_ (prefixed with the string ``icon-``) that will be displayed next
+to the group name.
+
+``page_reload``
+~~~~~~~~~~~~~~~
+
+**type**: ``boolean`` (**default**: ``false``)
+
+By default, JavaScript is used to open a group in the configuration tree. Set this option to
+``true`` to force a full page reload.
+
+``title``
+~~~~~~~~~
+
+**type**: ``string``
+
+The name of the group. The configured string will be translated before being displayed in the user
+interface.
+
+``tree``
+--------
+
+**type**: ``map``
+
+This option creates a hierarchical tree of configuration options as they will be presented in the
+user interface. Each key of the map refers to either the name of a
+:ref:`group <reference-format-system-configuration-groups>` or the name of
+a :ref:`configuration option <reference-format-system-configuration-fields>`. The values are maps
+that configure how each node is rendered in the UI. Available options for each node are:
+
+``children``
+~~~~~~~~~~~~
+
+**type**: ``list|map``
+
+The names of child nodes (fields or groups) mapped to their configuration. This option is only
+available when the current node is a group.
+
+``priority``
+~~~~~~~~~~~~
+
+**type**: ``integer`` **default**: ``0``
+
+The trees from the configuration files of all bundles will be merged into one large tree. The
+``priority`` option can be used to control the order in which nodes from different configuration
+files will be merged into the final tree. Nodes with a higher priority are shown first.
+
+.. _`system_configuration.yml file`: https://github.com/orocrm/platform/blob/master/src/Oro/Bundle/ActivityListBundle/Resources/config/system_configuration.yml
+.. _`ActivityListBundle`: https://github.com/orocrm/platform/blob/master/src/Oro/Bundle/ActivityListBundle/README.md
+.. _`Font Awesome Icon`: http://fontawesome.io/3.2.1/icons/

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -6,12 +6,15 @@ Reference
 * :doc:`/reference/format/index`
 
   * :doc:`/reference/format/acl`
+  * :doc:`/reference/format/assets`
   * :doc:`/reference/format/dashboard`
   * :doc:`/reference/format/datagrid`
   * :doc:`/reference/format/entity_config`
   * :doc:`/reference/format/navigation`
   * :doc:`/reference/format/placeholders`
   * :doc:`/reference/format/requirejs`
+  * :doc:`/reference/format/search`
+  * :doc:`/reference/format/system_configuration`
   * :doc:`/reference/format/workflow`
 
 .. toctree::


### PR DESCRIPTION
This is based on #146 and adds missing references for the `assets`, `search`, and `system_configuration` configuration formats.