### PR TITLE
Update functional_tests.rst

### DIFF
--- a/book/functional_tests.rst
+++ b/book/functional_tests.rst
@@ -86,6 +86,11 @@ commands:
 
     $ app/console oro:install --env test --organization-name Oro --user-name admin --user-email admin@example.com --user-firstname John --user-lastname Doe --user-password admin --sample-data n --application-url http://localhost --force
     $ app/console doctrine:fixture:load --no-debug --append --no-interaction --env=test --fixtures ./vendor/oro/platform/src/Oro/Bundle/TestFrameworkBundle/Fixtures
+
+For platform versions prior to 1.9 run command to update schema for test entities:
+
+.. code-block:: bash
+
     $ app/console oro:test:schema:update --env test
 
 After this, you'll be able to run your tests in a command line or IDE, e.g.:


### PR DESCRIPTION
- `oro:test:schema:update` no longer required for ~1.9