### PR TITLE
Wrong relation for workflowStep in documentation

### DIFF
--- a/book/workflow.rst
+++ b/book/workflow.rst
@@ -211,11 +211,13 @@ entity in this workflow:
 
         /**
          * @ORM\OneToOne(targetEntity="Oro\Bundle\WorkflowBundle\Entity\WorkflowItem")
+         * @ORM\JoinColumn(name="workflow_item_id", referencedColumnName="id", onDelete="SET NULL")
          */
         private $workflowItem;
 
         /**
          * @ORM\ManyToOne(targetEntity="Oro\Bundle\WorkflowBundle\Entity\WorkflowStep")
+         * @ORM\JoinColumn(name="workflow_step_id", referencedColumnName="id", onDelete="SET NULL")
          */
         private $workflowStep;
 
@@ -244,4 +246,7 @@ entity in this workflow:
 
     You do not need to create those methods for extended entities or for entities created in the
     user interface. The needed properties and methods will be automatically generated when the first
-    workflow is applied to them.
+    workflow is applied to them. 
+    
+    In 1.10 release there is no need to explicitly create any of these properties or methods but use  
+    trait WorkflowAwareTrait instead.

--- a/book/workflow.rst
+++ b/book/workflow.rst
@@ -215,7 +215,7 @@ entity in this workflow:
         private $workflowItem;
 
         /**
-         * @ORM\OneToOne(targetEntity="Oro\Bundle\WorkflowBundle\Entity\WorkflowStep")
+         * @ORM\ManyToOne(targetEntity="Oro\Bundle\WorkflowBundle\Entity\WorkflowStep")
          */
         private $workflowStep;
 

--- a/book/workflow.rst
+++ b/book/workflow.rst
@@ -246,7 +246,5 @@ entity in this workflow:
 
     You do not need to create those methods for extended entities or for entities created in the
     user interface. The needed properties and methods will be automatically generated when the first
-    workflow is applied to them. 
-    
-    In 1.10 release there is no need to explicitly create any of these properties or methods but use  
-    trait WorkflowAwareTrait instead.
+    workflow is applied to them. If you use Configurable Entity (and added workflow in config annotations) 
+    there is no need to explicitly create any of these properties or methods.


### PR DESCRIPTION
I think OneToOne is wrong, in crm other relation is used:

```
        * @var WorkflowStep
        * @ORM\ManyToOne(targetEntity="Oro\Bundle\WorkflowBundle\Entity\WorkflowStep")
```

   https://github.com/orocrm/crm/blob/693f6fb8306c07a4914996bb659457246f997ef5/src/OroCRM/Bundle/SalesBundle/Entity/SalesFunnel.php
