### PR TITLE
Escaping slashes in twig MUST be applied

### DIFF
--- a/cookbook/entities/import_export.rst
+++ b/cookbook/entities/import_export.rst
@@ -141,7 +141,7 @@ do so:
 
     {% block navButtons %}
         {% include 'OroImportExportBundle:ImportExport:buttons.html.twig' with {
-            entity_class: 'AppBundle\Entity\Task',
+            entity_class: 'AppBundle\\Entity\\Task',
             exportProcessor: 'app_task',
             exportTitle: 'Export',
             importProcessor: 'app_task',


### PR DESCRIPTION
According to current example if you pass this parameter:  entity_class: 'AppBundle\Entity\Task' without escaping twig will remove slashes and wrong import link will be generated. This will cause wrong behaviour in Oro Import stuff.